### PR TITLE
Fix imports for CDKTF Docker Provider v11

### DIFF
--- a/src/main/kotlin/com/iodeslykos/cdktf/AppTemplateStack.kt
+++ b/src/main/kotlin/com/iodeslykos/cdktf/AppTemplateStack.kt
@@ -1,10 +1,10 @@
 package com.iodeslykos.cdktf
 
 import com.hashicorp.cdktf.TerraformStack
-import com.hashicorp.cdktf.providers.docker.Container
-import com.hashicorp.cdktf.providers.docker.ContainerPorts
-import com.hashicorp.cdktf.providers.docker.DockerProvider
-import com.hashicorp.cdktf.providers.docker.Image
+import com.hashicorp.cdktf.providers.docker.container.Container
+import com.hashicorp.cdktf.providers.docker.container.ContainerPorts
+import com.hashicorp.cdktf.providers.docker.image.Image
+import com.hashicorp.cdktf.providers.docker.provider.DockerProvider
 import software.constructs.Construct
 
 

--- a/src/test/kotlin/com/iodeslykos/cdktf/AppTemplateTest.kt
+++ b/src/test/kotlin/com/iodeslykos/cdktf/AppTemplateTest.kt
@@ -3,8 +3,8 @@ package com.iodeslykos.cdktf
 import com.hashicorp.cdktf.App
 import com.hashicorp.cdktf.TerraformStack
 import com.hashicorp.cdktf.Testing
-import com.hashicorp.cdktf.providers.docker.Container
-import com.hashicorp.cdktf.providers.docker.Image
+import com.hashicorp.cdktf.providers.docker.container.Container
+import com.hashicorp.cdktf.providers.docker.image.Image
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
Changes from v10.x to v11.x were breaking, I suppose.